### PR TITLE
Poll login count

### DIFF
--- a/log.md
+++ b/log.md
@@ -1,3 +1,25 @@
+## 2025-06-15T05:38:30Z — Refresh login count
+
+**Task Overview**:
+Add periodic polling to keep login counter accurate across open tabs.
+
+**Context**:
+The login tracker only updated on page load. Opening new tabs changed the count without updating already loaded pages.
+
+**Thought Process**:
+Needed to update each page regularly without new dependencies. Polling via chrome.runtime.sendMessage suits.
+
+**Chosen Solution**:
+Use setInterval to request the current count every second from the background script and update the counter DOM.
+
+**Implementation**:
+- Added getCount function in src/content-script.js.
+- Updated injectCounter to use a span for the count.
+- Started a one second interval that fetches and injects updated counts.
+
+**Impact Summary**:
+Counters now stay in sync across tabs, showing accurate totals.
+
 ## 2025-06-15T01:11:42Z — Namespace window styles
 
 **Task Overview**:

--- a/src/content-script.js
+++ b/src/content-script.js
@@ -11,6 +11,14 @@ function incrementCount() {
   });
 }
 
+function getCount() {
+  return new Promise((resolve) => {
+    chrome.runtime.sendMessage({ action: "getCount" }, (resp) => {
+      resolve(resp ? resp.count : 0);
+    });
+  });
+}
+
 function injectCounter(count) {
   let counter = document.getElementById(pf("login-count-tracker"));
   if (!counter) {
@@ -28,7 +36,13 @@ function injectCounter(count) {
     counter.style.fontSize = "14px";
     document.body.appendChild(counter);
   }
-  counter.textContent = `Logins: ${count}`;
+  let countSpan = document.getElementById(pf("login-count"));
+  if (!countSpan) {
+    countSpan = document.createElement("span");
+    countSpan.id = pf("login-count");
+    counter.appendChild(countSpan);
+  }
+  countSpan.textContent = `Logins: ${count}`;
 
   let btn = document.getElementById(pf('app-launch-btn'));
   if (!btn) {
@@ -48,4 +62,8 @@ function injectCounter(count) {
 (async () => {
   const count = await incrementCount();
   injectCounter(count);
+  setInterval(async () => {
+    const latest = await getCount();
+    injectCounter(latest);
+  }, 1000);
 })();


### PR DESCRIPTION
## Summary
- add `getCount` helper for background data
- replace counter text node with a span element
- poll background script every second to refresh the display
- document work in `log.md`

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_684e5be566408328af058cffa49cdae2