### PR TITLE
Add daily login counter

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,12 +9,12 @@ This extension records how many times you visit `https://login.microsoftonline.c
 
 ## Dexie Setup
 
-`dexie.min.js` is bundled with the extension. A single IndexedDB store named `counters` holds a record with the key `"loginCount"`.
+`dexie.min.js` is bundled with the extension. A single IndexedDB store named `counters` holds a record with the key `"loginCount"`. Daily counts are stored in keys formatted as `loginCount_YYYY_MM_DD` using the local date.
 
-The background worker manages the value and exposes two actions via `chrome.runtime.sendMessage`:
+The background worker manages these values and exposes actions via `chrome.runtime.sendMessage`:
 
-- `increment` – increments the count and returns the updated value.
-- `getCount` – returns the current count.
+- `increment` – increments both totals and returns the updated numbers.
+- `getCounts` – returns the total and today's count.
 
 The content script increments the count each time the login page loads and injects a small UI element showing `Logins: <number>`.
 

--- a/log.md
+++ b/log.md
@@ -1,3 +1,25 @@
+## 2025-06-15T06:38:07Z — Track daily logins
+
+**Task Overview**:
+Add a per-day login counter stored in IndexedDB and display it in both the in-page UI and popup.
+
+**Context**:
+The extension only tracked total login counts.
+
+**Thought Process**:
+Used local date to create keys for daily counts. Needed to update background, content script and popup to fetch and display both totals. Ensured style remained simple.
+
+**Chosen Solution**:
+Added helper functions in background.js to manage daily records. Introduced new getCounts message returning both totals. Updated content and popup scripts to show Logins today line.
+
+**Implementation**:
+- Updated `src/background.js` with daily count functions and message handling.
+- Modified `src/content-script.js` to render two count lines and poll both values.
+- Adjusted `popup/popup.js` and `popup/popup.html` for the new daily display.
+- Documented the new behavior in `README.md`.
+
+**Impact Summary**:
+Users now see today's login count alongside the overall total, stored per local day for accuracy.
 ## 2025-06-15T06:00:17Z — Show tenant info
 
 **Task Overview**:

--- a/popup/popup.html
+++ b/popup/popup.html
@@ -7,7 +7,8 @@
 </head>
 <body>
   <div class="header">Microsoft Login Visits</div>
-  <div id="count" class="count">0</div>
+  <div>Logins: <span id="count" class="count">0</span></div>
+  <div>Logins today: <span id="daily-count" class="count">0</span></div>
   <script type="module" src="popup.js"></script>
 </body>
 </html>

--- a/popup/popup.js
+++ b/popup/popup.js
@@ -1,13 +1,19 @@
-function getCount() {
+function getCounts() {
   return new Promise((resolve) => {
-    chrome.runtime.sendMessage({ action: "getCount" }, (resp) => {
-      resolve(resp ? resp.count : 0);
+    chrome.runtime.sendMessage({ action: "getCounts" }, (resp) => {
+      if (resp) {
+        resolve(resp);
+      } else {
+        resolve({ count: 0, daily: 0 });
+      }
     });
   });
 }
 
 document.addEventListener("DOMContentLoaded", async () => {
   const countElem = document.getElementById("count");
-  const count = await getCount();
-  countElem.textContent = count;
+  const dailyElem = document.getElementById("daily-count");
+  const counts = await getCounts();
+  countElem.textContent = counts.count;
+  dailyElem.textContent = counts.daily;
 });

--- a/src/background.js
+++ b/src/background.js
@@ -12,14 +12,37 @@ async function setCount(val) {
   await db.counters.put({ key: "loginCount", value: val });
 }
 
+function getTodayKey() {
+  const d = new Date();
+  const pad = (n) => n.toString().padStart(2, "0");
+  return `loginCount_${d.getFullYear()}_${pad(d.getMonth() + 1)}_${pad(d.getDate())}`;
+}
+
+async function getDailyCount() {
+  const record = await db.counters.get(getTodayKey());
+  return record ? record.value : 0;
+}
+
+async function setDailyCount(val) {
+  await db.counters.put({ key: getTodayKey(), value: val });
+}
+
 chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
-  if (msg.action === "getCount") {
+  if (msg.action === "getCounts") {
+    Promise.all([getCount(), getDailyCount()]).then(([count, daily]) => {
+      sendResponse({ count, daily });
+    });
+    return true;
+  } else if (msg.action === "getCount") {
     getCount().then((count) => sendResponse({ count }));
     return true;
   } else if (msg.action === "increment") {
-    getCount().then((count) => {
+    Promise.all([getCount(), getDailyCount()]).then(([count, daily]) => {
       const next = count + 1;
-      setCount(next).then(() => sendResponse({ count: next }));
+      const nextDaily = daily + 1;
+      Promise.all([setCount(next), setDailyCount(nextDaily)]).then(() => {
+        sendResponse({ count: next, daily: nextDaily });
+      });
     });
     return true;
   }


### PR DESCRIPTION
## Summary
- display today's login count next to total logins
- store the per-day count using local date in IndexedDB
- update popup to show the new value
- document new daily counter

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684e69b682148328b35a84f0a5286dca